### PR TITLE
Add mention of kubernetes-core and kubeup.sh for developers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ knowledge. It is comprised of the following components and features:
 
 # Usage
 
+This bundle is for multi-node deployments, for individual deployments for developers, use the
+smaller [kubernetes-core](http://jujucharms.com/kubernetes-core) bundle, or
+ [kubeup.sh](http://kubernetes.io/docs/getting-started-guides/juju/). 
+
 ## Deploy the bundle
 
     juju deploy canonical-kubernetes


### PR DESCRIPTION
I had Didier check the README since he's deployed k8s, his only feedback is that it wasn't obvious to him where he should go if he was a developer and didn't want the full hog production grade k8s. This fixes the readme to send people to the right place. 