### PR TITLE
README: remove --all-namespaces from kubectl get pv command

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ Use watch on your Kubernetes cluster like the following, you should see the PV
 become enlisted and be marked as available:
 
 ```
-$ watch kubectl get pv --all-namespaces
+$ watch kubectl get pv
 
 NAME CAPACITY   ACCESSMODES   STATUS    CLAIM              REASON    AGE
 


### PR DESCRIPTION
@mbruzek The README told me to do this:
```
$ kubectl get pv --all-namespaces
NAMESPACE   NAME      CAPACITY   ACCESSMODES   RECLAIMPOLICY   STATUS    CLAIM     REASON    AGE
persistentVolume is not namespaced
persistentVolume is not namespaced
persistentVolume is not namespaced
persistentVolume is not namespaced
```

I had to remove --all-namespaces:

```
$ kubectl get pv
NAME      CAPACITY   ACCESSMODES   RECLAIMPOLICY   STATUS      CLAIM     REASON    AGE
test      0          RWO           Retain          Available                       13m
test2     50M        RWO           Retain          Available                       10m
test3     50M        RWO           Retain          Available                       8m
test4     100G       RWO           Retain          Available                       3m
```

Cc @chuckbutler @wwwtyro 