### PR TITLE
Remove the test plan packages

### DIFF
--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -1,4 +1,3 @@
-# Bundle level test. Only execute the 20 and 30 class series of tests
 tests: "*"
 # Dont test the beats stack until they have passing CWR tests in their own
 # bundle
@@ -7,11 +6,4 @@ excludes:
   - topbeat
   - elasticsearch
   - kibana
-# Adding tims PPA so we get current dependencies
-sources:
-  - ppa:tvansteenburgh/ppa
-packages:
-  - amulet
-  - juju-deployer
-  - python-jujuclient
 reset: false


### PR DESCRIPTION
The ppa/test-plan packages have created a packaging vortex of
dependencies that cannot be resolved at present. This removes those and
relies on the test env to have current 2.0 test tooling. This may be
problematic in the future, but is a necessary change for now.