### PR TITLE
Bump etcd to latest edge channel release

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -66,7 +66,7 @@ services:
       "gui-x": "800"
       "gui-y": "1150"
   etcd:
-    charm: "cs:~containers/etcd-19"
+    charm: "cs:~containers/etcd-20"
     num_units: 3
     annotations:
       "gui-x": "800"

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -66,13 +66,15 @@ services:
       "gui-x": "800"
       "gui-y": "1150"
   etcd:
-    charm: "cs:~containers/etcd-17"
+    charm: "cs:~containers/etcd-19"
     num_units: 3
     annotations:
       "gui-x": "800"
       "gui-y": "550"
 #    constraints: cpu-cores=2 root-disk=12G
 relations:
+  - - "etcd:certificates"
+    - "easyrsa:client"
   - - "filebeat:beats-host"
     - "kubernetes-worker:juju-info"
   - - "elasticsearch:client"


### PR DESCRIPTION
This moves etcd to a version which integrates with the CA. this allows for
a more robust deployment, by allowing the CA to be offline deployable. This
is a backwords incompatible change.