### PR TITLE
Bump etcd and flannel

### DIFF
--- a/bundle.yaml
+++ b/bundle.yaml
@@ -7,7 +7,7 @@ services:
     charm: cs:~containers/etcd-22
     num_units: 3
   flannel:
-    charm: cs:~containers/flannel-8
+    charm: cs:~containers/flannel-9
   kubeapi-load-balancer:
     charm: cs:~containers/kubeapi-load-balancer-5
     expose: true

--- a/bundle.yaml
+++ b/bundle.yaml
@@ -4,10 +4,10 @@ services:
     charm: cs:~containers/easyrsa-5
     num_units: 1
   etcd:
-    charm: cs:~containers/etcd-21
+    charm: cs:~containers/etcd-22
     num_units: 3
   flannel:
-    charm: cs:~containers/flannel-7
+    charm: cs:~containers/flannel-8
   kubeapi-load-balancer:
     charm: cs:~containers/kubeapi-load-balancer-5
     expose: true


### PR DESCRIPTION
Hotfix release for etcd and flannel bugs for testing. Currently lives in the
store as cs:~containers/bundle/canonical-kubernetes-16