### PR TITLE
Fix: grab tests dir from the projects root_path

### DIFF
--- a/bundle
+++ b/bundle
@@ -187,7 +187,9 @@ def main():
     with open(out_readme_filename, 'w') as out_readme_file:
         out_readme_file.write(readme)
     # Copy tests to every bundle
-    shutil.copytree('tests', os.path.join(out_bundle_name, 'tests'))
+    tests_src = os.path.join(root_path, 'tests')
+    tests_dst = os.path.join(out_bundle_name, 'tests')
+    shutil.copytree(tests_src, tests_dst)
     print('Done. Your bundle can be found in %s' %
           os.path.abspath(out_bundle_name))
 


### PR DESCRIPTION
If you call "bundle" from outside the directory it is in tests directory will not be found. This PR fixes this.