### PR TITLE
Create bundles that include the ci-info.yaml file

### DIFF
--- a/bundle
+++ b/bundle
@@ -54,6 +54,7 @@ def fragment_paths(fragment):
     return {
         'root': frag_path,
         'bundle': os.path.join(frag_path, 'bundle.yaml'),
+        'ci_info': os.path.join(frag_path, 'ci-info.yaml'),
         'readme': os.path.join(frag_path, 'README.md')
     }
 
@@ -74,6 +75,9 @@ def validate_components(fragments):
             raise FragmentUnknown('Unknown fragment ' + frag)
         if not os.path.exists(paths['bundle']):
             err = 'Fragment %s does not contain bundle.yaml' % frag
+            raise FragmentMissingComponent(err)
+        if not os.path.exists(paths['ci_info']):
+            err = 'Fragment %s does not contain ci-info.yaml' % frag
             raise FragmentMissingComponent(err)
         if not os.path.exists(paths['readme']):
             err = 'Fragment %s does not contain README.md' % frag
@@ -145,8 +149,10 @@ def serialize(bundle):
     out = ''
     for o in otherwise:
         out += yaml.dump(o, default_flow_style=False)
-    out += yaml.dump(services, default_flow_style=False)
-    out += yaml.dump(relations, default_flow_style=False)
+    if bool(services):
+        out += yaml.dump(services, default_flow_style=False)
+    if bool(relations):
+        out += yaml.dump(relations, default_flow_style=False)
     return out
 
 
@@ -157,6 +163,7 @@ def main():
     validate_components(args.fragments)
     validate_channel(args.channel)
     bundle = {}
+    ci_info = {}
     readme = ""
     for frag in args.fragments:
         print('Processing fragment %s...' % frag)
@@ -164,18 +171,26 @@ def main():
         with open(paths['bundle'], 'r') as f:
             frag_bundle = yaml.load(f)
         merge(frag_bundle, bundle)
+        with open(paths['ci_info'], 'r') as f:
+            frag_ci_info = yaml.load(f)
+        merge(frag_ci_info, ci_info)
         with open(paths['readme'], 'r') as f:
             frag_readme = f.read()
         readme = '\n'.join([readme, frag_readme])
+    ci_info['bundle']['name'] = os.path.basename(args.outputdir)
     if args.channel == 'local':
         bundle = local_bundle(bundle, args.localpath)
     else:
         bundle = version_bundle(bundle, args.channel)
     out_bundle_name = os.path.abspath(args.outputdir)
     out_bundle_filename = os.path.join(out_bundle_name, 'bundle.yaml')
+    out_ci_info_filename = os.path.join(out_bundle_name, 'ci-info.yaml')
     out_readme_filename = os.path.join(out_bundle_name, 'README.md')
     if os.path.isfile(out_bundle_filename):
         err = '%s already exists. Aborting.' % out_bundle_filename
+        raise FileExistsError(err)
+    if os.path.isfile(out_ci_info_filename):
+        err = '%s already exists. Aborting.' % out_ci_info_filename
         raise FileExistsError(err)
     if os.path.isfile(out_readme_filename):
         err = '%s already exists. Aborting.' % out_readme_filename
@@ -184,6 +199,8 @@ def main():
         os.makedirs(out_bundle_name)
     with open(out_bundle_filename, 'w') as out_bundle_file:
         out_bundle_file.write(serialize(bundle))
+    with open(out_ci_info_filename, 'w') as out_ci_info_file:
+        out_ci_info_file.write(serialize(ci_info))
     with open(out_readme_filename, 'w') as out_readme_file:
         out_readme_file.write(readme)
     # Copy tests to every bundle

--- a/bundle
+++ b/bundle
@@ -187,7 +187,9 @@ def main():
     with open(out_readme_filename, 'w') as out_readme_file:
         out_readme_file.write(readme)
     # Copy tests to every bundle
-    shutil.copytree('tests', os.path.join(out_bundle_name, 'tests'))
+    tests_src = os.path.join(root_path, 'tests')
+    tests_dst = os.path.join(out_bundle_name, 'tests')
+    shutil.copytree(tests_src, tests_dst)
     print('Done. Your bundle can be found in %s' %
           os.path.abspath(out_bundle_name))
 

--- a/fragments/cni/calico/ci-info.yaml
+++ b/fragments/cni/calico/ci-info.yaml
@@ -1,0 +1,5 @@
+# This is an incomplete bundle fragment. Do not attempt to deploy.
+charm-upgrade:
+  calico:
+    from-channel: edge
+    release: false

--- a/fragments/cni/flannel/ci-info.yaml
+++ b/fragments/cni/flannel/ci-info.yaml
@@ -1,0 +1,5 @@
+# This is an incomplete bundle fragment. Do not attempt to deploy.
+charm-upgrade:
+  flannel:
+    from-channel: edge
+    release: false

--- a/fragments/k8s/cdk/ci-info.yaml
+++ b/fragments/k8s/cdk/ci-info.yaml
@@ -1,6 +1,6 @@
 # This is an incomplete ci-info.yaml fragment.
 bundle:
-  namespace: kos.tsakalozos
+  namespace: containers
   release: true
   to-channel: edge
 charm-upgrade:

--- a/fragments/k8s/cdk/ci-info.yaml
+++ b/fragments/k8s/cdk/ci-info.yaml
@@ -1,0 +1,21 @@
+# This is an incomplete ci-info.yaml fragment.
+bundle:
+  namespace: kos.tsakalozos
+  release: true
+  to-channel: edge
+charm-upgrade:
+  kubernetes-master:
+    from-channel: edge
+    release: false
+  kubeapi-load-balancer:
+    from-channel: edge
+    release: false
+  easyrsa:
+    from-channel: edge
+    release: false
+  kubernetes-worker:
+    from-channel: edge
+    release: false
+  etcd:
+    from-channel: edge
+    release: false

--- a/fragments/k8s/core/ci-info.yaml
+++ b/fragments/k8s/core/ci-info.yaml
@@ -1,6 +1,6 @@
 # This is an incomplete ci-info.yaml fragment.
 bundle:
-  namespace: kos.tsakalozos
+  namespace: containers
   release: true
   to-channel: edge
 charm-upgrade:

--- a/fragments/k8s/core/ci-info.yaml
+++ b/fragments/k8s/core/ci-info.yaml
@@ -1,0 +1,18 @@
+# This is an incomplete ci-info.yaml fragment.
+bundle:
+  namespace: kos.tsakalozos
+  release: true
+  to-channel: edge
+charm-upgrade:
+  kubernetes-master:
+    from-channel: edge
+    release: false
+  easyrsa:
+    from-channel: edge
+    release: false
+  kubernetes-worker:
+    from-channel: edge
+    release: false
+  etcd:
+    from-channel: edge
+    release: false

--- a/fragments/monitor/elastic/ci-info.yaml
+++ b/fragments/monitor/elastic/ci-info.yaml
@@ -1,0 +1,14 @@
+# This is an incomplete ci-info fragment. Do not use as is.
+charm-upgrade:
+  filebeat:
+    from-channel: stable
+    release: false
+  elasticsearch:
+    from-channel: stable
+    release: false
+  topbeat:
+    from-channel: stable
+    release: false
+  kibana:
+    from-channel: stable
+    release: false


### PR DESCRIPTION
I am not totally sold on this approach. Consider this PR as an RFC.

We need to have a ci-info.yaml inside the bundles so that cwr ci would know which charms would need updating and releasing.
