### PR TITLE
Removing version badges as they are not tied to bundles data.

### DIFF
--- a/fragments/k8s/cdk/README.md
+++ b/fragments/k8s/cdk/README.md
@@ -1,6 +1,6 @@
 # The Canonical Distribution of Kubernetes
 
-![](https://img.shields.io/badge/release-beta-yellow.svg) ![](https://img.shields.io/badge/kubernetes-1.5.1-brightgreen.svg) ![](https://img.shields.io/badge/juju-2.0+-brightgreen.svg)
+![](https://img.shields.io/badge/release-beta-yellow.svg) ![](https://img.shields.io/badge/juju-2.0+-brightgreen.svg)
 
 ## Overview
 

--- a/fragments/k8s/core/README.md
+++ b/fragments/k8s/core/README.md
@@ -1,6 +1,6 @@
 # Kubernetes Core Bundle
 
-![](https://img.shields.io/badge/release-beta-yellow.svg) ![](https://img.shields.io/badge/kubernetes-1.4.5-brightgreen.svg) ![](https://img.shields.io/badge/juju-2.0+-brightgreen.svg)
+![](https://img.shields.io/badge/release-beta-yellow.svg) ![](https://img.shields.io/badge/juju-2.0+-brightgreen.svg)
 
 ## Overview
 


### PR DESCRIPTION
The version depends on what resource is uploaded to the charm at the time. This is not something that is tied to the bundle metadata. It is tied to the resource which is a separate process. The person who added these "cute" little badge is not keeping the versions current and I can not think of a way to do this automatically in our CI system so I am removing the version badges now.