### PR TITLE
Fix failing tests

### DIFF
--- a/tests/20-charm-validation.py
+++ b/tests/20-charm-validation.py
@@ -44,16 +44,29 @@ class IntegrationTest(unittest.TestCase):
         cls.deployment.sentry.wait_for_messages(application_messages,
                                                 timeout=900)
 
-        # Make every unit available through self reference
-        # eg: for worker in self.workers:
-        #         print(worker.info['public-address'])
-        cls.easyrsas = cls.deployment.sentry['easyrsa']
-        cls.etcds = cls.deployment.sentry['etcd']
-        cls.flannels = cls.deployment.sentry['flannel']
-        cls.loadbalancers = cls.deployment.sentry['kubeapi-load-balancer']
-        cls.masters = cls.deployment.sentry['kubernetes-master']
-        cls.workers = cls.deployment.sentry['kubernetes-worker']
+    @property
+    def easyrsas(self):
+        return self.deployment.sentry['easyrsa']
 
+    @property
+    def etcds(self):
+        return self.deployment.sentry['etcd']
+
+    @property
+    def flannels(self):
+        return self.deployment.sentry['flannel']
+
+    @property
+    def loadbalancers(self):
+        return self.deployment.sentry['kubeapi-load-balancer']
+
+    @property
+    def masters(self):
+        return self.deployment.sentry['kubernetes-master']
+
+    @property
+    def workers(self):
+        return self.deployment.sentry['kubernetes-worker']
 
     def test_master_services(self):
         '''Test if the master services are running.'''
@@ -168,7 +181,6 @@ class IntegrationTest(unittest.TestCase):
 
         self.assertNotEqual(scaled_apiserver, '')
 
-
         # determine we have the same number of servers as defined in the
         # topology
         server_string = scaled_apiserver.split(" ")[-1]
@@ -178,7 +190,6 @@ class IntegrationTest(unittest.TestCase):
         # determine that the actual etcd server string has changed to reflect
         # the number of etcd units in the apiserver connection string.
         self.assertNotEqual(scaled_apiserver, orig_apiserver)
-
 
 
 if __name__ == '__main__':

--- a/tests/20-charm-validation.py
+++ b/tests/20-charm-validation.py
@@ -145,7 +145,7 @@ class IntegrationTest(unittest.TestCase):
             if '--etcd-servers' in line:
                 orig_apiserver = line
 
-        self.assertFalse(orig_apiserver == '')
+        self.assertNotEqual(orig_apiserver, '')
 
         # discover the leader
         for unit in self.etcds:
@@ -166,7 +166,7 @@ class IntegrationTest(unittest.TestCase):
             if '--etcd-servers' in line:
                 scaled_apiserver = line
 
-        self.assertFalse(scaled_apiserver == '')
+        self.assertNotEqual(scaled_apiserver, '')
 
 
         # determine we have the same number of servers as defined in the
@@ -174,10 +174,10 @@ class IntegrationTest(unittest.TestCase):
         server_string = scaled_apiserver.split(" ")[-1]
         split_servers = server_string.split(",")
 
-        self.assertTrue(len(split_servers) == len(self.etcds))
+        self.assertEqual(len(split_servers), len(self.etcds))
         # determine that the actual etcd server string has changed to reflect
         # the number of etcd units in the apiserver connection string.
-        self.assertFalse(scaled_apiserver == orig_apiserver)
+        self.assertNotEqual(scaled_apiserver, orig_apiserver)
 
 
 

--- a/tests/tests.yaml
+++ b/tests/tests.yaml
@@ -1,11 +1,7 @@
 tests: "*"
-# Dont test the beats stack until they have passing CWR tests in their own
-# bundle
+# Exclude individual charm tests, only run bundle tests
 excludes:
-  - filebeat
-  - topbeat
-  - elasticsearch
-  - kibana
+  - 'cs:'
 # Adding tims PPA so we get current dependencies
 sources:
   - ppa:tvansteenburgh/ppa


### PR DESCRIPTION
Fix failing tests in two ways:

1. Exclude charm tests from running (we run these separately)
2. Use properties to allow for dynamic scaling of applications

To elaborate a bit on the properties, this is the failure I was seeing:

```
Traceback (most recent call last):
  File "/tmp/bundletester-ZqEPa8/wd/tests/20-charm-validation.py", line 177, in test_etcd_scale_on_master
    self.assertTrue(len(split_servers) == len(self.etcds))
AssertionError: False is not true
```

This happens because `self.etcds` is not updated after removing a unit of etcd.

Not only is this a problem for the assert in `test_etcd_scale_on_master`, but it also has the potential to mess up other tests as well - `self.etcds` is a list that's generated only once during `setUpClass`, and is shared across multiple tests.

Rewriting `self.etcds` as a property makes it more dynamic, and usable in the way that this test wants to use it. But it's possible it could lead to unexpected behavior in other ways. I'm not 100% sure it's the best way to go, but it does make the tests pass at least.