### PR TITLE
Add tests for labels and master restart action

### DIFF
--- a/tests/20-charm-validation.py
+++ b/tests/20-charm-validation.py
@@ -149,7 +149,7 @@ class IntegrationTest(unittest.TestCase):
             # self.assertTrue('KubeDNS is running' in output)
 
     def test_labels(self):
-        '''Test that kubectl is installed and the cluster appears healthy.'''
+        '''Test labels are set at deploy time and can be changed afterwards.'''
         nodes_describe_cmd = kubectl('describe no')
         output, rc = run(self.masters[0], nodes_describe_cmd)
         print("Output {}".format(output))


### PR DESCRIPTION
These two tests expose the following issues:
- https://github.com/juju-solutions/bundle-canonical-kubernetes/issues/299
- https://github.com/kubernetes/kubernetes/issues/47176

I would suggest we do the merge after the respective PRs are accepted so we do not break our CI.
