### PR TITLE
Improve assert output in security tests

### DIFF
--- a/tests/40-security-check.py
+++ b/tests/40-security-check.py
@@ -58,19 +58,19 @@ class IntegrationTest(unittest.TestCase):
         '''Test if the master services are accessible without credentials.'''
         url = 'https://{}:443/ui/'.format(self.loadbalancers[0].info['public-address'])
         r = requests.get(url, verify=False)
-        self.assertTrue(r.status_code == 401)
+        self.assertEqual(r.status_code, 401)
 
     def test_basic(self):
         '''Test the effect of changing the admin password'''
         ip = self.loadbalancers[0].info['public-address']
         # Try wrong password
         status = self.get_ui(ip, 'wrongpassword')
-        self.assertTrue(status == 401)
+        self.assertEqual(status, 401)
         # Get current password
         password = self.get_password()
-        self.assertTrue(password != 'admin')
+        self.assertNotEqual(password, 'admin')
         status = self.get_ui(ip, password)
-        self.assertTrue(status == 200)
+        self.assertEqual(status, 200)
         # Change password
         alpha = string.ascii_letters + string.digits
         new_password = ''.join(random.SystemRandom().choice(alpha) for _ in range(8))
@@ -81,9 +81,9 @@ class IntegrationTest(unittest.TestCase):
         time.sleep(20) # give a chance for reactive to run
         self.deployment.sentry.wait()
         status = self.get_ui(ip, password)
-        self.assertTrue(status == 401)
+        self.assertEqual(status, 401)
         status = self.get_ui(ip, new_password)
-        self.assertTrue(status == 200)
+        self.assertEqual(status, 200)
 
     def get_ui(self, ip_addr, password, user='admin'):
         url = "https://{}:443/ui/".format(ip_addr)


### PR DESCRIPTION
@ktsakalozos I'm troubleshooting this failure:

```
DEBUG:runner:Traceback (most recent call last):
DEBUG:runner:  File "/tmp/bundletester-m0ERzU/bundle-under-test/tests/40-security-check.py", line 73, in test_basic
DEBUG:runner:    self.assertTrue(status == 200)
DEBUG:runner:AssertionError: False is not true
```

This PR just updates the test to use `assertEqual` so we can see what status we're hitting.

I don't have capacity to run this locally ATM so I was hoping we could check this in, kick it off on Jenkins, and revisit later.