### PR TITLE
Revert "Use cpu-cores instead cores in constraints (#351)"

### DIFF
--- a/fragments/k8s/cdk/bundle.yaml
+++ b/fragments/k8s/cdk/bundle.yaml
@@ -30,7 +30,7 @@ services:
     options:
       channel: 1.7/stable
     expose: true
-    constraints: "cpu-cores=4 mem=4G"
+    constraints: "cores=4 mem=4G"
     annotations:
       "gui-x": "100"
       "gui-y": "850"

--- a/fragments/k8s/core/bundle.yaml
+++ b/fragments/k8s/core/bundle.yaml
@@ -30,7 +30,7 @@ services:
     options:
       channel: 1.7/stable
     expose: true
-    constraints: "cpu-cores=4 mem=4G"
+    constraints: "cores=4 mem=4G"
     annotations:
       "gui-x": "100"
       "gui-y": "850"
@@ -60,4 +60,4 @@ machines:
     series: xenial
   "1":
     series: xenial
-    constraints: "cpu-cores=4 mem=4G"
+    constraints: "cores=4 mem=4G"


### PR DESCRIPTION
cpu-cores is deprecated:

```
$ juju add-machine --constraints cpu-cores=1
Warning: constraint "cpu-cores" is deprecated in favor of "cores".
created machine 0
```

More importantly, it's breaking conjure-up deployments:

```
$ conjure-up --channel edge kubernetes-core aws/us-east-1 aws-dev test
[info] Summoning kubernetes-core to aws/us-east-1
[info] Running step: pre-deploy.
[error] Unsupported constraint: cpu-cores
[warning] Shutting down
```