### PR TITLE
Fix node counts in bundle docs

### DIFF
--- a/fragments/k8s/cdk/README.md
+++ b/fragments/k8s/cdk/README.md
@@ -7,7 +7,7 @@
 This is a scaled-out Kubernetes cluster composed of the following components and features:
 
 - Kubernetes (automated deployment, operations, and scaling)
-     - Three node Kubernetes cluster with one master and two worker nodes.
+     - Kubernetes cluster with one master and three worker nodes.
      - TLS used for communication between nodes for security.
      - A CNI plugin (Flannel)
      - A load balancer for HA kubernetes-master

--- a/fragments/k8s/core/README.md
+++ b/fragments/k8s/core/README.md
@@ -7,7 +7,7 @@
 This is a minimal Kubernetes cluster composed of the following components and features:
 
 - Kubernetes (automated deployment, operations, and scaling)
-     - Two-node Kubernetes cluster with one master node and one worker node.
+     - Kubernetes cluster with one master and one worker node.
      - TLS used for communication between nodes for security.
      - A CNI plugin (Flannel)
      - Optional Ingress Controller (on worker)


### PR DESCRIPTION
I took out the "three node" / "two-node" bit because it seems like it'd only cause confusion. Hope that's okay.