### PR TITLE
Default to stable channel if charm is not available on the expected one.

### DIFF
--- a/bundle
+++ b/bundle
@@ -119,7 +119,7 @@ def version_bundle(bundle, channel):
             err = "Couldn't query %s %s, is it public?" % (charm, channel)
             raise CharmstoreQueryError(err)
         if resp.text == "{}":
-            print("Service {} not avilable in channel {}. Using default channel (stable)."
+            print("Service {} not available in channel {}. Using default channel (stable)."
                   .format(service, channel))
             resp = requests.get('https://api.jujucharms.com/charmstore/v5/meta/id',
                                 params={'id': charm, 'channel': "stable"})

--- a/bundle
+++ b/bundle
@@ -118,6 +118,14 @@ def version_bundle(bundle, channel):
         if not resp.ok:
             err = "Couldn't query %s %s, is it public?" % (charm, channel)
             raise CharmstoreQueryError(err)
+        if resp.text == "{}":
+            print("Service {} not avilable in channel {}. Using default channel (stable)."
+                  .format(service, channel))
+            resp = requests.get('https://api.jujucharms.com/charmstore/v5/meta/id',
+                                params={'id': charm, 'channel': "stable"})
+            if not resp.ok:
+                err = "Couldn't query %s %s, is it public?" % (charm, channel)
+                raise CharmstoreQueryError(err)
         meta = json.loads(resp.text)
         meta = [meta[k] for k in meta][0]
         copy['services'][service]['charm'] = meta['Id']


### PR DESCRIPTION
Not 100% sure this is the right way to handle this error: https://ci.kubernetes.juju.solutions/job/build-and-release-all-charms-and-bundles/261/console