### PR TITLE
Bump default snap channels to 1.8/stable

### DIFF
--- a/fragments/k8s/cdk/bundle.yaml
+++ b/fragments/k8s/cdk/bundle.yaml
@@ -7,7 +7,7 @@ services:
     charm: "cs:~containers/kubernetes-master"
     num_units: 1
     options:
-      channel: 1.7/stable
+      channel: 1.8/stable
     annotations:
       "gui-x": "800"
       "gui-y": "850"
@@ -28,7 +28,7 @@ services:
     charm: "cs:~containers/kubernetes-worker"
     num_units: 3
     options:
-      channel: 1.7/stable
+      channel: 1.8/stable
     expose: true
     constraints: "cores=4 mem=4G"
     annotations:

--- a/fragments/k8s/core/bundle.yaml
+++ b/fragments/k8s/core/bundle.yaml
@@ -9,7 +9,7 @@ services:
     to:
       - "0"
     options:
-      channel: 1.7/stable
+      channel: 1.8/stable
     expose: true
     annotations:
       "gui-x": "800"
@@ -28,7 +28,7 @@ services:
     to:
       - "1"
     options:
-      channel: 1.7/stable
+      channel: 1.8/stable
     expose: true
     constraints: "cores=4 mem=4G"
     annotations:


### PR DESCRIPTION
1.8.0 snaps have been released to 1.8/stable. We can do this now.