### PR TITLE
Need to pin ES for now b/c newer versions break

### DIFF
--- a/fragments/monitor/elastic/bundle.yaml
+++ b/fragments/monitor/elastic/bundle.yaml
@@ -5,7 +5,7 @@ services:
     options:
       logpath: "/var/lib/docker/containers/*/*.log /var/log/*.log /var/log/*/*.log"
   elasticsearch:
-    charm: "cs:trusty/elasticsearch"
+    charm: "cs:trusty/elasticsearch-19"
     series: trusty
     num_units: 2
   topbeat:


### PR DESCRIPTION
revs 20 & 21 break with an error about needing Java 8 installed