### PR TITLE
Revert "Need to pin ES for now b/c newer versions break"

### DIFF
--- a/fragments/monitor/elastic/bundle.yaml
+++ b/fragments/monitor/elastic/bundle.yaml
@@ -5,7 +5,7 @@ services:
     options:
       logpath: "/var/lib/docker/containers/*/*.log /var/log/*.log /var/log/*/*.log"
   elasticsearch:
-    charm: "cs:trusty/elasticsearch-19"
+    charm: "cs:trusty/elasticsearch"
     series: trusty
     num_units: 2
   topbeat:


### PR DESCRIPTION
Reverts juju-solutions/bundle-canonical-kubernetes#427

Oops, need to revert this. Doesn't work when we pass `--channel edge` to the bundle script.