### PR TITLE
Increase the timeout for waiting on etcd unit removal

### DIFF
--- a/tests/20-charm-validation.py
+++ b/tests/20-charm-validation.py
@@ -193,7 +193,7 @@ class IntegrationTest(unittest.TestCase):
 
         # Now remove an etcd unit (in this case, the leader)
         self.deployment.remove_unit(leader.info['unit_name'])
-        self.deployment.sentry.wait()
+        self.deployment.sentry.wait(timeout=900)
 
         # Probe the arg file for all etcd members.
         scaled_api_conf = self.masters[0].file_contents(args)


### PR DESCRIPTION
Trying to fix flakyness in respective test. Happens often: 
https://ci.kubernetes.juju.solutions/job/build-and-release-all-charms-and-bundles/511/testReport/junit/(root)/bundle/20_charm_validation_py/
https://ci.kubernetes.juju.solutions/job/build-and-release-all-charms-and-bundles/513/testReport/junit/(root)/bundle/20_charm_validation_py/
