### PR TITLE
Adding keepalived to support loadbalancer failover

### DIFF
--- a/fragments/k8s/cdk/bundle.yaml
+++ b/fragments/k8s/cdk/bundle.yaml
@@ -40,11 +40,18 @@ services:
     annotations:
       "gui-x": "800"
       "gui-y": "550"
+  "keepalived":
+    charm: "cs:~boucherv29/keepalived"
+    annotations:
+      "gui-x": "475"
+      "gui-y": "150"
 relations:
   - - "kubernetes-master:kube-api-endpoint"
     - "kubeapi-load-balancer:apiserver"
   - - "kubernetes-master:loadbalancer"
-    - "kubeapi-load-balancer:loadbalancer"
+    - "keepalived:loadbalancer"
+  - - "keepalived:juju_info"
+    - "kubeapi-load-balancer:juju-info"
   - - "kubernetes-master:kube-control"
     - "kubernetes-worker:kube-control"
   - - "kubernetes-master:certificates"
@@ -56,6 +63,6 @@ relations:
   - - "kubernetes-worker:certificates"
     - "easyrsa:client"
   - - "kubernetes-worker:kube-api-endpoint"
-    - "kubeapi-load-balancer:website"
+    - "keepalived:website"
   - - "kubeapi-load-balancer:certificates"
     - "easyrsa:client"

--- a/tests/20-charm-validation.py
+++ b/tests/20-charm-validation.py
@@ -65,6 +65,10 @@ class IntegrationTest(unittest.TestCase):
         return self.deployment.sentry['flannel']
 
     @property
+    def keepaliveds(self):
+        return self.deployment.sentry['keepalived']
+
+    @property
     def loadbalancers(self):
         return self.deployment.sentry['kubeapi-load-balancer']
 

--- a/tests/30-unit-shuffle.py
+++ b/tests/30-unit-shuffle.py
@@ -52,6 +52,10 @@ class ShuffleTest(unittest.TestCase):
         return self.deployment.sentry['flannel']
 
     @property
+    def keepaliveds(self):
+        return self.deployment.sentry['keepalived']
+
+    @property
     def loadbalancers(self):
         return self.deployment.sentry['kubeapi-load-balancer']
 

--- a/tests/40-security-check.py
+++ b/tests/40-security-check.py
@@ -48,6 +48,7 @@ class IntegrationTest(unittest.TestCase):
         cls.easyrsas = cls.deployment.sentry['easyrsa']
         cls.etcds = cls.deployment.sentry['etcd']
         cls.flannels = cls.deployment.sentry['flannel']
+        cls.keepaliveds = cls.deployment.sentry['keepalived']
         cls.loadbalancers = cls.deployment.sentry['kubeapi-load-balancer']
         cls.masters = cls.deployment.sentry['kubernetes-master']
         cls.workers = cls.deployment.sentry['kubernetes-worker']


### PR DESCRIPTION
This PL is based on the issue #453 

The goal is to have a virtual ip shared in the lb api cluster
I updated the sdn-charmer keepalived charm to support xenial serie and python 3.5 with reactive etc..
We have to move this charm to an "official" repo.

If you have any suggestion, tell me!