### PR TITLE
use the latest xenial ES components (fixes #471)

### DIFF
--- a/fragments/monitor/elastic/bundle.yaml
+++ b/fragments/monitor/elastic/bundle.yaml
@@ -1,31 +1,34 @@
 # This is an incomplete bundle fragment. Do not attempt to deploy.
 services:
-  filebeat:
-    charm: "cs:filebeat"
-    options:
-      logpath: "/var/lib/docker/containers/*/*.log /var/log/*.log /var/log/*/*.log"
   elasticsearch:
-    charm: "cs:trusty/elasticsearch"
-    series: trusty
-    num_units: 2
-  topbeat:
-    charm: "cs:topbeat"
+    charm: "cs:xenial/elasticsearch"
+    num_units: 1
+  filebeat:
+    charm: cs:xenial/filebeat
+    options:
+      logpath: '/var/log/*.log'
+      kube_logs: True
   kibana:
-    charm: "cs:trusty/kibana"
-    series: trusty
+    charm: "cs:xenial/kibana"
     num_units: 1
     options:
       dashboards: beats
+      port: 8080
+    expose: true
+  topbeat:
+    charm: "cs:xenial/topbeat"
 relations:
-  - - "filebeat:beats-host"
-    - "kubernetes-worker:juju-info"
-  - - "elasticsearch:client"
-    - "topbeat:elasticsearch"
   - - "elasticsearch:client"
     - "filebeat:elasticsearch"
-  - - "topbeat:beats-host"
-    - "kubernetes-worker:juju-info"
+  - - "elasticsearch:client"
+    - "topbeat:elasticsearch"
   - - "filebeat:beats-host"
     - "kubernetes-master:juju-info"
+  - - "filebeat:beats-host"
+    - "kubernetes-worker:juju-info"
+  - - "topbeat:beats-host"
+    - "kubernetes-master:juju-info"
+  - - "topbeat:beats-host"
+    - "kubernetes-worker:juju-info"
   - - "kibana:rest"
     - "elasticsearch:client"

--- a/fragments/monitor/elastic/bundle.yaml
+++ b/fragments/monitor/elastic/bundle.yaml
@@ -4,7 +4,7 @@ services:
     charm: "cs:xenial/elasticsearch"
     num_units: 1
   filebeat:
-    charm: cs:xenial/filebeat
+    charm: "cs:xenial/filebeat"
     options:
       logpath: '/var/log/*.log'
       kube_logs: True


### PR DESCRIPTION
Update the elastic fragment to use the latest xenial charm versions.

Note: this changes the topology to deploy a single ES unit. I'm not sure why there were 2 units to begin with, but 2 is 1 too many for this fragment.  If users want to scale out their ES bits, they're free to use `juju add-unit`.

Note 2: this configures kibana for port 8080.  Otherwise, if it happens to land on a worker, port 80 might conflict with the ingress controller.