### PR TITLE
bump 20-charm-validation test_ns sleep

### DIFF
--- a/tests/20-charm-validation.py
+++ b/tests/20-charm-validation.py
@@ -242,7 +242,7 @@ class IntegrationTest(unittest.TestCase):
                                                full_output=True)
         self.assertEqual(outcome['status'], 'completed')
         # Allow for kubernetes to remove the namespace
-        time.sleep(10)
+        time.sleep(30)
         action_id = self.masters[0].run_action('namespace-list')
         outcome = self.deployment.action_fetch(action_id,
                                                timeout=7200,


### PR DESCRIPTION
In a handful of local bundletester jobs for cdk-flannel, the time
it takes for the `namespace-delete` action to be reflected by
`namespace-list` ranges from 5-15 seconds.

Increase the sleep time between delete and list to give slower
deletions time to settle.