### PR TITLE
adjust constraints for k8s master/workers

### DIFF
--- a/fragments/k8s/cdk/bundle.yaml
+++ b/fragments/k8s/cdk/bundle.yaml
@@ -8,7 +8,7 @@ services:
     num_units: 1
     options:
       channel: 1.10/stable
-    constraints: "root-disk=16G"
+    constraints: "cores=2 mem=4G root-disk=16G"
     annotations:
       "gui-x": "800"
       "gui-y": "850"
@@ -33,7 +33,7 @@ services:
     options:
       channel: 1.10/stable
     expose: true
-    constraints: "cores=4 mem=4G root-disk=16G"
+    constraints: "cores=2 mem=4G root-disk=16G"
     annotations:
       "gui-x": "100"
       "gui-y": "850"

--- a/fragments/k8s/cdk/bundle.yaml
+++ b/fragments/k8s/cdk/bundle.yaml
@@ -33,7 +33,7 @@ services:
     options:
       channel: 1.10/stable
     expose: true
-    constraints: "cores=2 mem=4G root-disk=16G"
+    constraints: "cores=4 mem=4G root-disk=16G"
     annotations:
       "gui-x": "100"
       "gui-y": "850"

--- a/fragments/k8s/core/bundle.yaml
+++ b/fragments/k8s/core/bundle.yaml
@@ -11,6 +11,7 @@ services:
     options:
       channel: 1.10/stable
     expose: true
+    constraints: "cores=2 mem=4G root-disk=16G"
     annotations:
       "gui-x": "800"
       "gui-y": "850"
@@ -30,7 +31,7 @@ services:
     options:
       channel: 1.10/stable
     expose: true
-    constraints: "cores=4 mem=4G"
+    constraints: "cores=4 mem=4G root-disk=16G"
     annotations:
       "gui-x": "100"
       "gui-y": "850"
@@ -58,7 +59,7 @@ relations:
 machines:
   "0":
     series: xenial
-    constraints: "mem=4G root-disk=16G"
+    constraints: "cores=2 mem=4G root-disk=16G"
   "1":
     series: xenial
     constraints: "cores=4 mem=4G root-disk=16G"


### PR DESCRIPTION
We've heard recent reports from the field that cdk won't deploy on Azure. This is because default VMs in Azure come with 1 core and 1.6G ram, which is just barely enough for the apiserver to start, let alone be performant.

Adjust the CDK and k8s-core bundle constraints on k8s-[master|worker] to handle this.  For CDK, both master and workers should have at least 2 cores, 4g ram, and 16g disk.  The minimum for k8s-core is similar, with a minimum of 4 cores for k8s-worker since we only have 1 worker in this setup (note: this is not new, we've always requested 4 cores for the k8s-worker in k8s-core).