### PR TITLE
Move easyrsa in its own machine

### DIFF
--- a/fragments/k8s/cdk/bundle.yaml
+++ b/fragments/k8s/cdk/bundle.yaml
@@ -27,8 +27,6 @@ services:
     annotations:
       "gui-x": "450"
       "gui-y": "550"
-    to:
-      - lxd:kubernetes-master
   "kubernetes-worker":
     charm: "cs:~containers/kubernetes-worker"
     num_units: 3


### PR DESCRIPTION
Moving easyrsa to its own machine because 
- bundletester cannot scp to lxc containers.
