### PR TITLE
ES needs at least 4G to start up reliably

### DIFF
--- a/fragments/monitor/elastic/bundle.yaml
+++ b/fragments/monitor/elastic/bundle.yaml
@@ -1,7 +1,8 @@
 # This is an incomplete bundle fragment. Do not attempt to deploy.
 services:
   elasticsearch:
-    charm: "cs:xenial/elasticsearch"
+    charm: "cs:bionic/elasticsearch"
+    constraints: mem=4G root-disk=16G
     num_units: 1
   filebeat:
     charm: "cs:xenial/filebeat"


### PR DESCRIPTION
davecore noticed that ES didn't start reliably on GCE.  make sure the bundle sets an appropriate constraint.

Switch to bionic while we're here.  It's been running well for me for a while now.