### PR TITLE
Adds post deployment script for jaas/jujushell

### DIFF
--- a/fragments/k8s/cdk-converged/post-deployment.sh
+++ b/fragments/k8s/cdk-converged/post-deployment.sh
@@ -1,0 +1,1 @@
+k8s-postdeploy

--- a/fragments/k8s/cdk/post-deployment.sh
+++ b/fragments/k8s/cdk/post-deployment.sh
@@ -1,0 +1,1 @@
+k8s-postdeploy

--- a/fragments/k8s/core/post-deployment.sh
+++ b/fragments/k8s/core/post-deployment.sh
@@ -1,0 +1,1 @@
+k8s-postdeploy


### PR DESCRIPTION
https://github.com/juju/jujushell has added support for post-deployment commands to be run in the gui. This feature in the gui looks for a file in bundles, post-deployment.sh, and sends commands listed there to the jujushell.

Additionally, we'e added a k8s specific post deploy command to the limited shell used in jaas, which this added post-deploy script uses.