### PR TITLE
Update NVIDIA bundle for 1.13

### DIFF
--- a/poc/bundle.yaml
+++ b/poc/bundle.yaml
@@ -1,4 +1,4 @@
-series: xenial
+series: bionic
 description: >
   PREVIEW (AWS only): A seven-machine Kubernetes cluster. Includes a
   three-machine etcd cluster and one GPU-enabled Kubernetes worker node.
@@ -7,50 +7,74 @@ services:
     annotations:
       gui-x: '450'
       gui-y: '550'
-    charm: cs:~containers/easyrsa-40
+    charm: cs:~containers/easyrsa-195
     constraints: root-disk=8G
     num_units: 1
+    resources:
+      easyrsa: 5
   etcd:
     annotations:
       gui-x: '800'
       gui-y: '550'
-    charm: cs:~containers/etcd-80
+    charm: cs:~containers/etcd-338
     constraints: root-disk=8G
     num_units: 3
     options:
       channel: 3.2/stable
+    resources:
+      etcd: 3
+      snapshot: 0
   flannel:
     annotations:
       gui-x: '450'
       gui-y: '750'
-    charm: cs:~containers/flannel-56
+    charm: cs:~containers/flannel-351
+    resources:
+      flannel-amd64: 16
+      flannel-arm64: 15
+      flannel-s390x: 5
   kubeapi-load-balancer:
     annotations:
       gui-x: '450'
       gui-y: '250'
-    charm: cs:~containers/kubeapi-load-balancer-58
+    charm: cs:~containers/kubeapi-load-balancer-525
     constraints: root-disk=8G
     expose: true
     num_units: 1
+    resources: {}
   kubernetes-master:
     annotations:
       gui-x: '800'
       gui-y: '850'
-    charm: cs:~containers/kubernetes-master-104
+    charm: cs:~containers/kubernetes-master-542
     constraints: cores=2 mem=4G root-disk=16G
     num_units: 1
     options:
-      channel: 1.10/stable
+      channel: 1.13/stable
+    resources:
+      cdk-addons: 0
+      kube-apiserver: 0
+      kube-controller-manager: 0
+      kube-proxy: 0
+      kube-scheduler: 0
+      kubectl: 0
   kubernetes-worker:
     annotations:
       gui-x: '100'
       gui-y: '850'
-    charm: cs:~containers/kubernetes-worker-118
+    charm: cs:~containers/kubernetes-worker-398
     constraints: instance-type=p2.xlarge root-disk=16G
     expose: true
     num_units: 1
     options:
-      channel: 1.10/stable
+      channel: 1.13/stable
+    resources:
+      cni-amd64: 12
+      cni-arm64: 10
+      cni-s390x: 11
+      kube-proxy: 0
+      kubectl: 0
+      kubelet: 0
 relations:
 - - kubernetes-master:kube-api-endpoint
   - kubeapi-load-balancer:apiserver


### PR DESCRIPTION
Needed to update this to Bionic anyway, for series compatibility with the subordinate charms deployed by the Graylog/Prometheus addons in conjure-up.